### PR TITLE
PTF-2030: Migrate to azure-ci, part 2

### DIFF
--- a/azure-devops/npm-publish.yml
+++ b/azure-devops/npm-publish.yml
@@ -22,6 +22,7 @@ resources:
   - repository: pipelines
     type: github
     name: hivestreaming/azure-ci
+    ref: refs/heads/PTF-2030_migrate-to-azure-ci
     #     ref: refs/heads/EE-1_my-awesome-feature # pin to a specific branch during development
     endpoint: hivestreaming  # Azure DevOps service connection.
 

--- a/azure-devops/npm-publish.yml
+++ b/azure-devops/npm-publish.yml
@@ -22,7 +22,6 @@ resources:
   - repository: pipelines
     type: github
     name: hivestreaming/azure-ci
-    ref: refs/heads/PTF-2030_migrate-to-azure-ci
     #     ref: refs/heads/EE-1_my-awesome-feature # pin to a specific branch during development
     endpoint: hivestreaming  # Azure DevOps service connection.
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -7,8 +7,8 @@
     "hive-jwt-util": "./dist/cli/hive-jwt-util.js"
   },
   "scripts": {
-    "build": "npm run clean && tsc -b && chmod +x node_modules/typedoc/bin/typedoc && ./node_modules/typedoc/bin/typedoc src/lib/index.ts",
-    "clean": "rm -rf docs dist",
+    "build": "npm run clean && tsc -b && typedoc src/lib/index.ts",
+    "clean": "rimraf docs dist",
     "prepack": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
Remove the file attributes hack from the previous commit, now that the underlying problem with `CopyFiles@2` has been fixed.